### PR TITLE
Drop useless -AlegacyConfigRoot=true compiler argument

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -45,9 +45,6 @@
               <version>${quarkus.version}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Removing as I'm trying to get a proper picture of extensions still using legacy config classes.

I would appreciate a quick merge :).

Thanks!