### PR TITLE
Upgrade checkout and setup-java actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,9 @@ jobs:
         run: git config --global core.autocrlf false
         if: startsWith(matrix.os, 'windows')
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17


### PR DESCRIPTION
## Motivation

The action that builds PRs is consistently failing with:
```shell
Resolved Java 17.0.15+6 from tool-cache
Setting Java 17.0.15+6 as the default

Java configuration:
  Distribution: temurin
  Version: 17.0.15+6
  Path: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.15-6/x64

Creating settings.xml with server-id: github
Writing to /home/runner/.m2/settings.xml
Error: Cache service responded with 422
```

This appears to be caused by an outdated version of `@actions/cache`, as detailed in https://github.com/actions/setup-node/issues/1275 .