### PR TITLE
Release quarkus-couchbase 1.1.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: "1.0.0"
+  current-version: "1.1.0"
   next-version: "999-SNAPSHOT"


### PR DESCRIPTION
Release `quarkus-couchbase` 1.1.0, which upgrades the following:

- Upgrade Couchbase Java SDK from 3.7.7 -> 3.8.0
- Upgrade metrics-micrometer from 0.7.6 -> 0.8.0
- Upgrade Quarkus from 3.17.5 -> 3.20.0
- Upgrade @ConfigMapping annotation in NettyBuildTimeConfig to use the new @ConfigRoot (to remove AlegacyConfigRoot=true compiler argument)
- Remove Graal arguments from native-image.properties in favour of a BuildStep in CouchbaseProcessor
- Update Netty processing