### PR TITLE
SDK 3.9.2 Upgrade

### DIFF
--- a/deployment/src/main/java/com/couchbase/quarkus/extension/deployment/CouchbaseProcessor.java
+++ b/deployment/src/main/java/com/couchbase/quarkus/extension/deployment/CouchbaseProcessor.java
@@ -32,7 +32,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -191,17 +190,5 @@ public class CouchbaseProcessor {
     @BuildStep
     NativeImageResourceBuildItem nativeImageResourceBuildItem() {
         return new NativeImageResourceBuildItem("com/couchbase/client/core/env/capella-ca.pem");
-    }
-
-    @BuildStep
-    NativeImageConfigBuildItem nettyCompressionRuntimeInit() {
-        NativeImageConfigBuildItem.Builder builder = NativeImageConfigBuildItem.builder();
-        builder.addRuntimeInitializedClass(
-                "com.couchbase.client.core.deps.io.netty.handler.codec.compression.ZlibCodecFactory");
-        builder.addRuntimeInitializedClass(
-                "com.couchbase.client.core.deps.io.netty.handler.codec.compression.JZlibDecoder");
-        builder.addRuntimeInitializedClass(
-                "com.couchbase.client.core.deps.io.netty.handler.codec.compression.JZlibEncoder");
-        return builder.build();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,9 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.26.3</quarkus.version>
+    <quarkus.version>3.28.4</quarkus.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <couchbase.client.version>3.9.1</couchbase.client.version>
+    <couchbase.client.version>3.9.2</couchbase.client.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
- Upgrade to Quarkus 3.28.4
- Upgrade Couchbase Java SDK to 3.9.2
- Upgrade netty substitutions 