### PR TITLE
docs: fix broken xref links to external URLs

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -1,6 +1,6 @@
 = Couchbase Configuration
 
-Full details can be found in the xref:https://javadoc.io/doc/io.quarkiverse.couchbase/quarkus-couchbase/latest/com/couchbase/quarkus/extension/runtime/CouchbaseConfig.html.[CouchbaseConfig API Reference].
+Full details can be found in the https://javadoc.io/doc/io.quarkiverse.couchbase/quarkus-couchbase/latest/com/couchbase/quarkus/extension/runtime/CouchbaseConfig.html[CouchbaseConfig API Reference].
 
 Currently, a minimal set of configuration options for the `Cluster` bean is provided.
 
@@ -41,7 +41,7 @@ These config items have default values, but can be overridden in `application.pr
 ** *Default*: `3`
 
 === Security
-Refer to the xref:https://docs.couchbase.com/java-sdk/current/ref/client-settings.html#security-options[Couchbase Java SDK Documentation] for further details on security options.
+Refer to the https://docs.couchbase.com/java-sdk/current/ref/client-settings.html#security-options[Couchbase Java SDK Documentation] for further details on security options.
 All the following options use the underlying Couchbase Java SDK's default values if unset.
 
 * `quarkus.couchbase.security.enableTls`
@@ -54,6 +54,3 @@ All the following options use the underlying Couchbase Java SDK's default values
 ** *String*: A comma-separated list of cipher suites to enable.
 * `quarkus.couchbase.security.trustCertificate`
 ** *String*: A path to a single PEM-encoded certificate file.
-
-
-

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -108,7 +108,7 @@ You can enable Micrometer metrics by adding the following dependencies to your a
 
 Set `quarkus.couchbase.metrics.enabled=true` in `application.properties`.
 The emission rate is also configurable with `quarkus.couchbase.metrics.emit-interval`.
-It is recommended to enable histograms which aren't enabled by default. Configuring the `MeterRegistry` is explained on the xref:https://quarkus.io/guides/telemetry-micrometer#customizing-micrometer[Quarkus Docs] and xref:https://docs.couchbase.com/java-sdk/current/howtos/observability-metrics.html#micrometer-integration[Couchbase docs].
+It is recommended to enable histograms which aren't enabled by default. Configuring the `MeterRegistry` is explained on the https://quarkus.io/guides/telemetry-micrometer#customizing-micrometer[Quarkus Docs] and https://docs.couchbase.com/java-sdk/current/howtos/observability-metrics.html#micrometer-integration[Couchbase docs].
 
 == Unsupported Features
 


### PR DESCRIPTION
## Summary
- Fix xref targets that point to external URLs (should use link syntax instead)
- Fix trailing dot in CouchbaseConfig javadoc URL

These errors show up in the Antora docs build:
- target of xref not found: https://javadoc.io/doc/...CouchbaseConfig.html.
- target of xref not found: https://docs.couchbase.com/.../client-settings.html#security-options
- target of xref not found: https://quarkus.io/guides/telemetry-micrometer.adoc#customizing-micrometer
- target of xref not found: https://docs.couchbase.com/.../observability-metrics.html#micrometer-integration